### PR TITLE
Feature/resource output and options typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "r3shaper",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Isolate and normalize the API layer of your app.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -8,6 +8,7 @@ import { TransformersInterface } from './interfaces/transformers.interface';
 import { Methods } from './enums/methods.enum';
 import { Resource } from './Resource';
 import { Route } from './Route';
+import { FetchBodyInterface } from './interfaces/fetch-body.interface';
 
 export class Client implements ClientInterface {
   static config: ClientConfigInterface = {
@@ -24,83 +25,110 @@ export class Client implements ClientInterface {
     this.apiProvider = config.apiProvider || Client.config.apiProvider;
   }
 
-  public get(path: string, transformers: TransformersInterface = {}) {
-    return this._createResource(
+  public get<T = any, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T> = {}
+  ): FetchFunctionInterface<T, S> {
+    return this._createResource<T, S>(
       new Route(Methods.GET, path),
       transformers.onRequest,
       transformers.onResponse
     );
   }
 
-  public head(path: string, transformers: TransformersInterface = {}) {
-    return this._createResource(
+  public head<T = any, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T> = {}
+  ): FetchFunctionInterface<T, S> {
+    return this._createResource<T, S>(
       new Route(Methods.HEAD, path),
       transformers.onRequest,
       transformers.onResponse
     );
   }
 
-  public post(path: string, transformers: TransformersInterface = {}) {
-    return this._createResource(
+  public post<T = any, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T> = {}
+  ): FetchFunctionInterface<T, S> {
+    return this._createResource<T, S>(
       new Route(Methods.POST, path),
       transformers.onRequest,
       transformers.onResponse
     );
   }
 
-  public put(path: string, transformers: TransformersInterface = {}) {
-    return this._createResource(
+  public put<T = any, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T> = {}
+  ): FetchFunctionInterface<T, S> {
+    return this._createResource<T, S>(
       new Route(Methods.PUT, path),
       transformers.onRequest,
       transformers.onResponse
     );
   }
 
-  public delete(path: string, transformers: TransformersInterface = {}) {
-    return this._createResource(
+  public delete<T = any, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T> = {}
+  ): FetchFunctionInterface<T, S> {
+    return this._createResource<T, S>(
       new Route(Methods.DELETE, path),
       transformers.onRequest,
       transformers.onResponse
     );
   }
 
-  public connect(path: string, transformers: TransformersInterface = {}) {
-    return this._createResource(
+  public connect<T = any, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T> = {}
+  ): FetchFunctionInterface<T, S> {
+    return this._createResource<T, S>(
       new Route(Methods.CONNECT, path),
       transformers.onRequest,
       transformers.onResponse
     );
   }
 
-  public options(path: string, transformers: TransformersInterface = {}) {
-    return this._createResource(
+  public options<T = any, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T> = {}
+  ): FetchFunctionInterface<T, S> {
+    return this._createResource<T, S>(
       new Route(Methods.OPTIONS, path),
       transformers.onRequest,
       transformers.onResponse
     );
   }
 
-  public trace(path: string, transformers: TransformersInterface = {}) {
-    return this._createResource(
+  public trace<T = any, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T> = {}
+  ): FetchFunctionInterface<T, S> {
+    return this._createResource<T, S>(
       new Route(Methods.TRACE, path),
       transformers.onRequest,
       transformers.onResponse
     );
   }
 
-  public patch(path: string, transformers: TransformersInterface = {}) {
-    return this._createResource(
+  public patch<T = any, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T> = {}
+  ): FetchFunctionInterface<T, S> {
+    return this._createResource<T, S>(
       new Route(Methods.PATCH, path),
       transformers.onRequest,
       transformers.onResponse
     );
   }
 
-  private _createResource(
+  private _createResource<T = any, S = FetchBodyInterface | void>(
     route: RouteInterface,
     onRequest?: Function,
     onResponse?: Function
-  ): FetchFunctionInterface {
-    return new Resource(this, route, onRequest, onResponse).fetch;
+  ) {
+    return new Resource<T, S>(this, route, onRequest, onResponse).fetch;
   }
 }

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -7,7 +7,7 @@ import { FetchFunctionInterface } from './interfaces/fetch-function.interface';
 import { Client } from './Client';
 import { Route } from './Route';
 
-export class Resource implements ResourceInterface {
+export class Resource<T = any, S = FetchBodyInterface | void> implements ResourceInterface {
   private interceptors: InterceptorsInterface;
 
   constructor(
@@ -20,14 +20,12 @@ export class Resource implements ResourceInterface {
     this.interceptors = { onRequest, onResponse };
   }
 
-  public fetch: FetchFunctionInterface = ({
-    body,
-    params,
-    queryParams,
-    headers,
-    meta,
-  }: FetchBodyInterface = {}) => {
-    const normalizedBody = body ? this.interceptors.onRequest(body, meta) : undefined;
+  public fetch: FetchFunctionInterface<T, S> = (options: S) => {
+    const { body, params, queryParams, headers, meta } = (options || {}) as FetchBodyInterface;
+
+    const normalizedBody = body
+      ? this.interceptors.onRequest(body, meta)
+      : undefined;
 
     let fullPath = `${this.client.basePath}${this.route.path}`;
 

--- a/src/interfaces/client.interface.ts
+++ b/src/interfaces/client.interface.ts
@@ -1,15 +1,43 @@
 import { ClientConfigInterface } from './client-config.interface';
 import { FetchFunctionInterface } from './fetch-function.interface';
 import { TransformersInterface } from './transformers.interface';
+import { FetchBodyInterface } from './fetch-body.interface';
 
 export interface ClientInterface extends ClientConfigInterface {
-  get(path: string, transformers: TransformersInterface): FetchFunctionInterface;
-  head(path: string, transformers: TransformersInterface): FetchFunctionInterface;
-  post(path: string, transformers: TransformersInterface): FetchFunctionInterface;
-  put(path: string, transformers: TransformersInterface): FetchFunctionInterface;
-  delete(path: string, transformers: TransformersInterface): FetchFunctionInterface;
-  connect(path: string, transformers: TransformersInterface): FetchFunctionInterface;
-  options(path: string, transformers: TransformersInterface): FetchFunctionInterface;
-  trace(path: string, transformers: TransformersInterface): FetchFunctionInterface;
-  patch(path: string, transformers: TransformersInterface): FetchFunctionInterface;
+  get<T, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T>
+  ): FetchFunctionInterface<T, S>;
+  head<T, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T>
+  ): FetchFunctionInterface<T, S>;
+  post<T, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T>
+  ): FetchFunctionInterface<T, S>;
+  put<T, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T>
+  ): FetchFunctionInterface<T, S>;
+  delete<T, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T>
+  ): FetchFunctionInterface<T, S>;
+  connect<T, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T>
+  ): FetchFunctionInterface<T, S>;
+  options<T, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T>
+  ): FetchFunctionInterface<T, S>;
+  trace<T, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T>
+  ): FetchFunctionInterface<T, S>;
+  patch<T, S = FetchBodyInterface | void>(
+    path: string,
+    transformers: TransformersInterface<T>
+  ): FetchFunctionInterface<T, S>;
 }

--- a/src/interfaces/fetch-function.interface.ts
+++ b/src/interfaces/fetch-function.interface.ts
@@ -1,5 +1,8 @@
 import { FetchBodyInterface } from './fetch-body.interface';
 
-export interface FetchFunctionInterface {
-  (options?: FetchBodyInterface): Promise<any>;
+export interface FetchFunctionInterface<
+  T = any,
+  S = FetchBodyInterface | void
+> {
+  (options: S): Promise<T>;
 }

--- a/src/interfaces/resource.interface.ts
+++ b/src/interfaces/resource.interface.ts
@@ -1,5 +1,5 @@
 import { FetchBodyInterface } from './fetch-body.interface';
 
-export interface ResourceInterface {
-  fetch(params: FetchBodyInterface): Promise<any>;
+export interface ResourceInterface<T = any, S = FetchBodyInterface | void> {
+  fetch(options: S): Promise<T>;
 }

--- a/src/interfaces/transformers.interface.ts
+++ b/src/interfaces/transformers.interface.ts
@@ -1,6 +1,6 @@
 import { MetaType } from '../types/meta.type';
 
-export interface TransformersInterface {
+export interface TransformersInterface<T = any> {
   onRequest?: (data: any, meta?: MetaType) => any;
-  onResponse?: (data: any, meta?: MetaType) => any;
+  onResponse?: (data: any, meta?: MetaType) => T;
 }


### PR DESCRIPTION
### Description
This PR allows us to describe what a resource returns, implements option typings, and it doesn't introduce any breaking changes.

### Examples:
- Basic (nothing changes, so no breaking changes):
```ts
export const todosResource = {
  list: apiClient.get('/api/todos'),
};
```

- Generic output type specification:
```ts
type Todo = {
  completed: Boolean;
};

export const todosResource = {
  list: apiClient.get<Todo[]>('/api/todos'),
};
```
Now TypeScript knows that `todosResource.list` returns `Promise<Todo[]>`.

- Response interceptor output type specification:
```ts
type Todo = {
  completed: Boolean;
};

export const todosReosurce = {
  list: apiClient.get('/api/todos', {
    onResponse: (data): Todo[] => data,
  }),
};
```
Now TypeScript knows that `todosResource.list` returns `Promise<Todo[]>`.

- Mandatory options typings:
```ts
type Todo = {
  completed: Boolean;
};

export const todosReosurce = {
  find: apiClient.get<Todo[], { params: { id: number } }>('/api/todos/{id}'),
};
```
Now TypeScript knows that `todosResource.list` requires `options` with the specified structure. 

- Optional options typings:
```ts
type Todo = {
  completed: Boolean;
};

export const todosReosurce = {
  find: apiClient.get<Todo[], { params: { id: number } } | void>('/api/todos/{id}'),
};
```
Now TypeScript knows that `todosResource.list` can receive `options` with the specified structure, but the argument is not mandatory. 


